### PR TITLE
Harden planning API endpoints against CSRF and unauthorized access

### DIFF
--- a/planung/views.py
+++ b/planung/views.py
@@ -8,8 +8,8 @@ from django.http import JsonResponse
 from django.urls import reverse
 from django.utils.dateparse import parse_date
 from django.utils.translation import gettext as _
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_http_methods
 from django.views.decorators.http import require_POST
 from licenses.models import License
 from planung.services.plan_service import delete_day_plan
@@ -70,7 +70,6 @@ def get_license_by_number(request, number):
 
 @require_POST
 @staff_member_required
-@csrf_exempt
 def save_day_plan(request):
     """Save a day plan with the provided data."""
     try:
@@ -98,7 +97,8 @@ def save_day_plan(request):
         return JsonResponse({"error": str(e)}, status=400)
 
 
-@csrf_exempt
+@require_http_methods(["GET", "DELETE"])
+@staff_member_required
 def day_plan_detail(request, iso_date):
     """Retrieve or delete a day plan by ISO date.
 
@@ -244,7 +244,6 @@ def list_templates(request):
 
 @require_POST
 @staff_member_required
-@csrf_exempt
 def apply_template(request):
     """Apply a stored plan template to one target date."""
     payload = json.loads(request.body or "{}")
@@ -289,7 +288,6 @@ def apply_template(request):
 
 @require_POST
 @staff_member_required
-@csrf_exempt
 def copy_plan(request):
     """Copy plan from source date to target date."""
     payload = json.loads(request.body or "{}")


### PR DESCRIPTION
### Motivation
- Prevent CSRF and unintended public access on planning endpoints that modify or expose day plans by ensuring Django's standard protections and staff-only access are applied.

### Description
- Removed `@csrf_exempt` from `save_day_plan`, `apply_template`, and `copy_plan` so CSRF protection is enforced for state-changing endpoints.
- Restricted `day_plan_detail` to explicit HTTP methods with `@require_http_methods(["GET","DELETE"])` and added `@staff_member_required` to ensure only staff can read or delete plans.
- Updated imports to add `require_http_methods` and removed the now-unused `csrf_exempt` import; no business-logic changes were made.

### Testing
- `python -m py_compile planung/views.py` ran successfully and verified syntax.
- `python -m pytest planung/tests/test_views.py -q` was executed but could not complete in this environment due to a missing `celery` dependency.
- A repository scan (`rg`) for unsafe patterns was run and confirmed the removal of `@csrf_exempt` in `planung/views.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c4487eec833287576ec18c0a6ae5)